### PR TITLE
Better Third Party app detection.

### DIFF
--- a/CarPlayActivator/PrivateHeaders.h
+++ b/CarPlayActivator/PrivateHeaders.h
@@ -101,5 +101,10 @@ static inline BOOL carplay_active() { return [[NSFileManager defaultManager] fil
 @interface ABStarkContactsListViewController : UIViewController
 @end
 
+@interface LSApplicationProxy : NSObject
+-(NSDictionary *)entitlements;
++(id)applicationProxyForIdentifier:(id)arg1;
+@end
+
 #endif
 

--- a/CarPlayActivator/Tweak.xmi
+++ b/CarPlayActivator/Tweak.xmi
@@ -198,9 +198,10 @@ HOOK(FBWindowContextHostWrapperView)
   
   if (CARPLAY_ACTIVE) {
     NSString *identifier = [manager identifier];
+      LSApplicationProxy *proxy = [GET_CLASS(LSApplicationProxy) applicationProxyForIdentifier:identifier];
+      NSDictionary *entitlements = [proxy entitlements];
     
-    if ([identifier rangeOfString:@"spotify"].location != NSNotFound ||
-        [identifier rangeOfString:@"overcast"].location != NSNotFound) {
+    if (entitlements[@"com.apple.developer.playable-content"]) {
       [original setAlpha:0.0];
     }
   }
@@ -213,9 +214,10 @@ HOOK(FBWindowContextHostWrapperView)
   if (CARPLAY_ACTIVE) {
     id manager = [self manager];
     NSString *identifier = [manager identifier];
+      LSApplicationProxy *proxy = [GET_CLASS(LSApplicationProxy) applicationProxyForIdentifier:identifier];
+      NSDictionary *entitlements = [proxy entitlements];
     
-    if ([identifier rangeOfString:@"spotify"].location != NSNotFound ||
-        [identifier rangeOfString:@"overcast"].location != NSNotFound) {
+    if (entitlements[@"com.apple.developer.playable-content"]) {
       alpha = 0.0;
     }
   }


### PR DESCRIPTION
CarPlay Apps are required to have a specific entitlement set to display on the CarPlay home screen.  I updated the code to look for this entitlement rather than depend on the identifier.  This should scale better than having to update the check for all new apps.
